### PR TITLE
chore: simplify TypeScript build configuration

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
     "removeComments": true,
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
- Removed the "rootDir" property from tsconfig.build.json to streamline the build process.
- This change enhances the clarity and efficiency of the TypeScript configuration.