### PR TITLE
chore: update TypeORM configuration for environment-specific paths

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,7 +4,6 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "webpack": true,
     "tsConfigPath": "tsconfig.build.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "cross-env NODE_ENV=development nest start",
     "start:dev": "cross-env NODE_ENV=development nest start --watch",
     "start:debug": "cross-env NODE_ENV=development nest start --debug --watch",
-    "start:prod": "cross-env NODE_ENV=production node dist/main.js",
+    "start:prod": "cross-env NODE_ENV=production node dist/src/main.js",
     "prebuild:prod": "rimraf dist",
     "build:prod": "cross-env NODE_ENV=production nest build",
     "typeorm": "typeorm-ts-node-commonjs",

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -7,6 +7,7 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
   constructor(private configService: ConfigService) {}
 
   createTypeOrmOptions(): Promise<TypeOrmModuleOptions> | TypeOrmModuleOptions {
+    const isDevelopment = this.configService.get('NODE_ENV') === 'development';
     return {
       type: 'postgres',
       host: this.configService.get('DB_HOST'),
@@ -14,10 +15,14 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
       username: this.configService.get('DB_USERNAME'),
       password: this.configService.get('DB_PASSWORD'),
       database: this.configService.get('DB_NAME'),
-      entities: [__dirname + '/../**/*.entity{.ts,.js}'],
+      entities: isDevelopment
+        ? ['**/*.entity{.ts,.js}']
+        : ['dist/src/**/*.entity{.js}'],
       synchronize: false,
       migrationsRun: true,
-      migrations: [__dirname + '/../migrations/*{.ts,.js}'],
+      migrations: isDevelopment
+        ? ['src/migrations/*.ts']
+        : ['dist/src/migrations/*.js'],
       extra: {
         // Ensure extension is available when TypeORM syncs
         installExtensions: true,

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -3,6 +3,7 @@ import { DataSource, DataSourceOptions } from 'typeorm';
 
 dotenv.config({ path: `.env.${process.env.NODE_ENV || 'development'}` });
 
+const isDevelopment = process.env.NODE_ENV === 'development';
 export const appDataSource = new DataSource({
   type: 'postgres',
   host: process.env.DB_HOST,
@@ -10,6 +11,8 @@ export const appDataSource = new DataSource({
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME,
-  entities: ['**/*.entity.ts'],
-  migrations: [__dirname + '/../migrations/*.js'],
+  entities: isDevelopment ? ['**/*.entity.ts'] : ['dist/src/**/*.entity.js'],
+  migrations: isDevelopment
+    ? ['src/migrations/*.ts']
+    : ['dist/src/migrations/*.js'],
 } as DataSourceOptions);


### PR DESCRIPTION
- Introduced environment-based logic in typeorm.config.ts and data-source.ts to differentiate between development and production paths for entities and migrations.
- Adjusted the start:prod script in package.json to reflect the new output structure.
- Removed webpack option from nest-cli.json to streamline the configuration.