### PR TITLE
ISA-67-stock-search-broken

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -81,7 +81,6 @@ describe('AuthController', () => {
     authController = moduleRef.get<AuthController>(AuthController);
     authService = moduleRef.get<AuthService>(AuthService);
 
-    // Mock the getFrontendUrl method to return localhost for tests
     jest
       .spyOn(authController as any, 'getFrontendUrl')
       .mockReturnValue('http://localhost:3001');
@@ -109,7 +108,6 @@ describe('AuthController', () => {
 
       mockAuthService.signUp.mockResolvedValue(mockUserResponse);
 
-      // ✅ Fix: Fully mock the Express Response object
       const res = {
         cookie: jest.fn(),
         status: jest.fn().mockReturnThis(),
@@ -118,10 +116,8 @@ describe('AuthController', () => {
 
       const result = await authController.signUp(dto, res as Response);
 
-      // ✅ Ensure authService.signUp() was called with correct DTO
       expect(authService.signUp).toHaveBeenCalledWith(dto);
 
-      // ✅ Ensure cookie is set correctly
       expect(res.cookie).toHaveBeenCalledWith('access_token', 'mockJwtToken', {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
@@ -129,7 +125,6 @@ describe('AuthController', () => {
         path: '/',
       });
 
-      // ✅ Ensure structured response is returned
       expect(result).toEqual({
         message: 'User registered successfully',
         firstName: 'John',
@@ -156,15 +151,12 @@ describe('AuthController', () => {
         json: jest.fn(),
       } as Partial<Response>;
 
-      // ✅ Expect the function to throw UnauthorizedException
       await expect(authController.signUp(dto, res as Response)).rejects.toThrow(
         UnauthorizedException,
       );
 
-      // ✅ Ensure authService.signUp() was called with correct DTO
       expect(authService.signUp).toHaveBeenCalledWith(dto);
 
-      // ✅ Ensure cookie was NOT set due to error
       expect(res.cookie).not.toHaveBeenCalled();
     });
   });
@@ -193,9 +185,9 @@ describe('AuthController', () => {
 
         const res = {
           cookie: jest.fn(),
-        };
+        } as Partial<Response>;
 
-        const result = await authController.signIn(req, dto, res);
+        const result = await authController.signIn(req, dto, res as Response);
 
         expect(authService.loginWithJwt).toHaveBeenCalledWith(mockUser);
 
@@ -227,10 +219,10 @@ describe('AuthController', () => {
         user: mockUser,
       };
 
-      const res = { cookie: jest.fn() }; // Mock response object
-      await expect(authController.signIn(req, dto, res)).rejects.toThrow(
-        'Login failed',
-      );
+      const res = { cookie: jest.fn() } as Partial<Response>; // Mock response object
+      await expect(
+        authController.signIn(req, dto, res as Response),
+      ).rejects.toThrow('Login failed');
       expect(authService.loginWithJwt).toHaveBeenCalledWith(mockUser);
     });
   });

--- a/src/common/interceptors/custom-cache.interceptor.ts
+++ b/src/common/interceptors/custom-cache.interceptor.ts
@@ -28,10 +28,8 @@ export class CustomCacheInterceptor implements NestInterceptor {
       return next.handle();
     }
 
-    // Check if the endpoint has the no_cache metadata flag
     const noCache = this.reflector.get('no_cache', context.getHandler());
     if (noCache) {
-      // Skip caching for this endpoint
       return next.handle();
     }
 

--- a/src/common/interceptors/custom-cache.interceptor.ts
+++ b/src/common/interceptors/custom-cache.interceptor.ts
@@ -28,6 +28,13 @@ export class CustomCacheInterceptor implements NestInterceptor {
       return next.handle();
     }
 
+    // Check if the endpoint has the no_cache metadata flag
+    const noCache = this.reflector.get('no_cache', context.getHandler());
+    if (noCache) {
+      // Skip caching for this endpoint
+      return next.handle();
+    }
+
     const cacheKey = this.reflector.get('cache_key', context.getHandler());
     const ttl = this.reflector.get('cache_ttl', context.getHandler());
 

--- a/src/stock/stocks.controller.ts
+++ b/src/stock/stocks.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Post,
   Query,
+  SetMetadata,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
@@ -70,6 +71,7 @@ export class StocksController {
     description: 'Returns a list of stocks matching the search query',
     type: [SearchStockDto],
   })
+  @SetMetadata('no_cache', true)
   async searchStocks(@Query('query') query: string): Promise<SearchStockDto[]> {
     return this.stocksService.searchStocks(query);
   }


### PR DESCRIPTION
This pull request includes several changes to the `AuthController` tests, the `CustomCacheInterceptor`, and the `StocksService`. The changes primarily focus on improving code readability, adding metadata for caching, and optimizing stock search functionality.

### Changes to `AuthController` tests:

* Removed redundant comments to clean up the test code in `src/auth/auth.controller.spec.ts`. [[1]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL84) [[2]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL112) [[3]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL121-L132) [[4]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL159-L167) [[5]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL196-R190) [[6]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL230-R225)

### Changes to `CustomCacheInterceptor`:

* Added logic to check for a `no_cache` metadata flag and skip caching if the flag is present in `src/common/interceptors/custom-cache.interceptor.ts`.

### Changes to `StocksController`:

* Added `@SetMetadata('no_cache', true)` to the `searchStocks` method to prevent caching of search results in `src/stock/stocks.controller.ts`. [[1]](diffhunk://#diff-854cfed00d0778327a77e0b28bbecc0a0b2869df0cbc6e1f7d1fda157d7c13dcR10) [[2]](diffhunk://#diff-854cfed00d0778327a77e0b28bbecc0a0b2869df0cbc6e1f7d1fda157d7c13dcR74)

### Optimizations in `StocksService`:

* Refactored the `getTopStocksByMarketCap` method to remove unnecessary checks and improve readability in `src/stock/stocks.service.ts`.
* Optimized the `searchStocks` method for better performance and readability, including a more efficient query and logging of results in `src/stock/stocks.service.ts`. [[1]](diffhunk://#diff-8a8cea4ec88f73b03a7c972135421b1cdb5766f49447adc37b831df776817e04L324-R319) [[2]](diffhunk://#diff-8a8cea4ec88f73b03a7c972135421b1cdb5766f49447adc37b831df776817e04L335-R380)
* Added a condition to only fetch negative performers in the `getTopStocksByMarketCap` method in `src/stock/stocks.service.ts`.